### PR TITLE
Avoid panic in check_up_to_date on unexpected GitHub API response

### DIFF
--- a/kicad-wakatime/src/lib.rs
+++ b/kicad-wakatime/src/lib.rs
@@ -276,10 +276,10 @@ impl Plugin {
         return Ok(())
       }
     }
-    let name = json["name"]
-      .as_str()
-      .unwrap()
-      .to_string();
+    let Some(name) = json["name"].as_str() else {
+      warn!("Could not read version from GitHub API response");
+      return Ok(())
+    };
     if name != PLUGIN_VERSION {
       info!("kicad-wakatime update available!");
       info!("Visit https://github.com/hackclub/kicad-wakatime to download it");


### PR DESCRIPTION
`check_up_to_date` calls `.unwrap()` on `json["name"].as_str()`, which panics when the GitHub releases API returns a body without a `name` field. The existing sanity check only handles the `"Not Found"` message, so other responses (rate limiting, error payloads) hit the unwrap and crash the app on launch, as reported in #35.

This replaces the unwrap with a `let ... else` that logs a warning and returns `Ok(())`, matching the pattern already used a few lines above for the "Not Found" case.

I did not add a test since the version check goes through a live `reqwest::blocking` request and the crate has no HTTP mocking setup; `cargo check` passes.